### PR TITLE
Add raw DOT format output with diagram output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Example
 | `-o <output file>` | The file that the output will be written to.<br />Common file extensions: `.png`, `.pdf`, `.svg` |
 | `-c <config file>` | The JSON configuration file to use. |
 | `-d <max depth>` | The maximum hop depth to discover, starting at the root node specified by `-r` |
-| `-D <output DOT file>` | Output a raw DOT file for manual diagram edits; after editing, use graphviz to rebuild the diagram from a DOT file |
+| `-D <output DOT file>` | Output a raw DOT file for manual diagram edits; after editing, use graphviz to rebuild the diagram from a DOT file.  This option must be used with `-o` |
 | `-t <diagram title>` | The title to give your generated network diagram. |
 | `-C <catalog file>` | If specified, natlas will generate a comma separated (CSV) catalog file with a list of all devices discovered. |
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Example
 # natlas-cli.py diagram -r <root IP>
                 -o <output file>
                [-d <max depth>]
+               [-D <output DOT file>]
                [-c <config file>]
                [-t <diagram title>]
                [-C <catalog file>]
@@ -114,6 +115,7 @@ Example
 | `-o <output file>` | The file that the output will be written to.<br />Common file extensions: `.png`, `.pdf`, `.svg` |
 | `-c <config file>` | The JSON configuration file to use. |
 | `-d <max depth>` | The maximum hop depth to discover, starting at the root node specified by `-r` |
+| `-D <output DOT file>` | Output a raw DOT file for manual diagram edits; after editing, use graphviz to rebuild the diagram from a DOT file |
 | `-t <diagram title>` | The title to give your generated network diagram. |
 | `-C <catalog file>` | If specified, natlas will generate a comma separated (CSV) catalog file with a list of all devices discovered. |
 

--- a/modules/diagram.py
+++ b/modules/diagram.py
@@ -41,6 +41,7 @@ def mod_load(mod):
     mod.syntax      = '-r <root IP>\n'                          \
                       '        -o <output file>\n'              \
                       '        [-d <max depth>]\n'              \
+                      '        [-D <output DOT file>]\n'        \
                       '        [-c <config file>]\n'            \
                       '        [-t <diagram title>]\n'          \
                       '        [-C <catalog file>]'
@@ -49,14 +50,15 @@ def mod_load(mod):
     return 1
 
 def mod_entry(natlas_obj, argv):
-    opt_root_ip = None
-    opt_output  = None
-    opt_catalog = None
-    opt_depth   = DEFAULT_OPT_DEPTH
-    opt_title   = DEFAULT_OPT_TITLE
+    opt_root_ip         = None
+    opt_output          = None
+    opt_output_raw_dot  = None
+    opt_catalog         = None
+    opt_depth           = DEFAULT_OPT_DEPTH
+    opt_title           = DEFAULT_OPT_TITLE
 
     try:
-        opts, args = getopt.getopt(argv, 'o:d:r:t:F:c:C:')
+        opts, args = getopt.getopt(argv, 'o:d:r:t:F:c:C:D:')
     except getopt.GetoptError:
         print('Invalid arguments.')
         return
@@ -64,6 +66,7 @@ def mod_entry(natlas_obj, argv):
         if (opt == '-r'):   opt_root_ip = arg
         if (opt == '-o'):   opt_output = arg
         if (opt == '-d'):   opt_depth = int(arg)
+        if (opt == '-D'):   opt_output_raw_dot = arg
         if (opt == '-t'):   opt_title = arg
         if (opt == '-C'):   opt_catalog = arg
 
@@ -73,6 +76,7 @@ def mod_entry(natlas_obj, argv):
 
     print('     Config file: %s' % natlas_obj.config_file)
     print('     Output file: %s' % opt_output)
+    print(' Output DOT file: %s' % opt_output_raw_dot)
     print('Out Catalog file: %s' % opt_catalog)
     print('       Root node: %s' % opt_root_ip)
     print('  Discover depth: %s' % opt_depth)
@@ -85,7 +89,8 @@ def mod_entry(natlas_obj, argv):
     natlas_obj.discover_network(opt_root_ip, 1)
 
     # outputs
-    if (opt_output != None):    natlas_obj.write_diagram(opt_output, opt_title)
+    if (opt_output != None):    natlas_obj.write_diagram(opt_output, opt_title,
+        opt_output_raw_dot)
     if (opt_catalog != None):   natlas_obj.write_catalog(opt_catalog)
 
     return

--- a/natlas/natlas.py
+++ b/natlas/natlas.py
@@ -121,8 +121,8 @@ class natlas:
         node.query_node()
         return
 
-    def write_diagram(self, output_file, diagram_title): 
-        self.diagram.generate(output_file, diagram_title)
+    def write_diagram(self, output_file, diagram_title, output_raw_dot=None): 
+        self.diagram.generate(output_file, diagram_title, output_raw_dot)
 
     def write_catalog(self, output_file): 
         self.catalog.generate(output_file)

--- a/natlas/output_diagram.py
+++ b/natlas/output_diagram.py
@@ -52,7 +52,7 @@ class natlas_output_diagram:
         self.network = network
         self.config  = network.config
 
-    def generate(self, dot_file, title):
+    def generate(self, dot_file, title, raw_dot_file=None):
         self.network.reset_discovered()
 
         title_text_size = self.config.diagram.title_text_size
@@ -95,6 +95,10 @@ class natlas_output_diagram:
         # add all of the nodes and links
         self.__generate(diagram, self.network.root_node)
 
+#       ## Writing the raw DOT file
+        if raw_dot_file is not None:
+            diagram.write_dot(raw_dot_file)
+            print('Created DOT file: %s' % raw_dot_file)
 
         # expand output string
         files = util.expand_path_pattern(dot_file)


### PR DESCRIPTION
Sometimes it's useful to tweak the information or rendering of the auto-generated .svg map; however, all known editing tools for `.svg` format (such as inkscape) do not offer any real way to rearrange nodes without much pain.

In some cases, it's easier to change the DOT source itself and redraw / render the svg.  I forked natlas and created a `-D` option to create a dot file along with the automatic diagram.